### PR TITLE
fix(flake): use locked nix-darwin to avoid GitHub API rate limit on switch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -411,14 +411,18 @@
                   if [ "$IS_AI_AGENT" = true ]; then
                     ${
                       if isDarwin then
-                        "sudo nix run nix-darwin -- switch --flake .#${hostname}"
+                        "sudo ${
+                          nix-darwin.packages.${system}.darwin-rebuild
+                        }/bin/darwin-rebuild switch --flake .#${hostname}"
                       else
                         "nix run nixpkgs#home-manager -- switch --flake .#${username}"
                     }
                   else
                     ${
                       if isDarwin then
-                        "sudo nix run nix-darwin -- switch --flake .#${hostname} |& ${localPkgs.nix-output-monitor}/bin/nom"
+                        "sudo ${
+                          nix-darwin.packages.${system}.darwin-rebuild
+                        }/bin/darwin-rebuild switch --flake .#${hostname} |& ${localPkgs.nix-output-monitor}/bin/nom"
                       else
                         "nix run nixpkgs#home-manager -- switch --flake .#${username} |& ${localPkgs.nix-output-monitor}/bin/nom"
                     }


### PR DESCRIPTION
## Summary

- `nix run .#switch` was failing with HTTP 403 from `api.github.com/repos/nix-darwin/nix-darwin/commits/HEAD`
- Under `sudo`, `\$HOME` falls back to `/var/root` and the user's nix access tokens are no longer read, so `nix run nix-darwin` resolves the flakeref via the public registry and hits the anonymous rate limit
- Invoke `darwin-rebuild` from the locked `nix-darwin.packages.\${system}` input directly, so no registry HEAD lookup occurs

## Test plan

- [x] `nix run .#switch` completes successfully on aarch64-darwin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS system configuration update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->