### PR TITLE
docs: add missing tools skill

### DIFF
--- a/agents/skills/missing-tools/SKILL.md
+++ b/agents/skills/missing-tools/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: missing-tools
+description: Resolves missing CLI tools. Use when a command is unavailable, a shell reports command not found, or a tool must be run without installing it globally.
+---
+
+# Missing Tools
+
+Use this workflow when a command is unavailable in the current shell.
+
+## Priority Order
+
+1. Try the current project's direnv environment:
+
+   ```sh
+   direnv exec . <command>
+   ```
+
+2. Use [comma](https://github.com/nix-community/comma) for tools from nixpkgs:
+
+   ```sh
+   , <command>
+   ```
+
+3. Use `nix run` when a specific nixpkgs package is needed:
+
+   ```sh
+   nix run nixpkgs#<package> -- <args>
+   ```
+
+4. Use `nix shell` as the last resort:
+
+   ```sh
+   nix shell nixpkgs#<package> --command <command>
+   ```
+
+## Notes
+
+- Never install missing tools globally. Do not use commands such as `npm install -g`, `npm i -g`, `pnpm add -g`, `yarn global add`, `bun add -g`, `uv tool install`, `brew install`, or language-specific global installers to resolve a missing command.
+- Prefer `direnv exec .` first because project-local dev shells often already provide the right tool version and environment variables.
+- Comma automatically finds and runs the nixpkgs package containing the requested command.
+- Use fish for shell wrapping in this dotfiles environment:
+
+  ```sh
+  fish -c '<command>'
+  ```

--- a/claude/rules/tools.md
+++ b/claude/rules/tools.md
@@ -23,22 +23,7 @@ If `bunx <command>` fails, try: `bun x <command>`
 
 ## Missing Tools
 
-**Always use [comma](https://github.com/nix-community/comma) first** when a tool is not installed:
-
-```bash
-, <command>           # Run any command from nixpkgs without installing
-, cowsay "Hello"      # Example: run cowsay without installing it
-, htop                # Example: run htop temporarily
-```
-
-Comma automatically finds and runs the package containing the command.
-
-**Priority order** for running unavailable tools:
-
-1. `direnv exec . <command>` - when you need environment variables from direnv
-2. `, <command>` (comma) - preferred, simplest
-3. `nix run nixpkgs#<package>` - when you need a specific package name
-4. `nix shell nixpkgs#<package> --command <command>` - last resort
+Use the `missing-tools` skill when a command is unavailable, a shell reports `command not found`, or a tool must be run without installing it globally.
 
 ## Tips
 

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -33,22 +33,7 @@ The following tools are preferred and available globally:
 
 ## Missing Tools
 
-**Always use [comma](https://github.com/nix-community/comma) first** when a tool is not installed:
-
-```bash
-, <command>           # Run any command from nixpkgs without installing
-, cowsay "Hello"      # Example: run cowsay without installing it
-, htop                # Example: run htop temporarily
-```
-
-Comma automatically finds and runs the package containing the command.
-
-**Priority order** for running unavailable tools:
-
-1. `direnv exec . <command>` - when you need environment variables from direnv
-2. `, <command>` (comma) - preferred, simplest
-3. `nix run nixpkgs#<package>` - when you need a specific package name
-4. `nix shell nixpkgs#<package> --command <command>` - last resort
+Use the `missing-tools` skill when a command is unavailable, a shell reports `command not found`, or a tool must be run without installing it globally.
 
 ## Social Media Posts & YouTube Transcripts
 


### PR DESCRIPTION
Move duplicated missing-tool fallback guidance into a shared local agent skill so Codex and Claude references stay consistent.

Keep direnv exec as the first fallback, followed by comma, nix run, and nix shell, and replace the duplicated AGENTS/rules sections with short skill routing guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized “missing CLI tools” guidance into a shared agent skill for consistent behavior across Codex and Claude. Removed duplicated docs and routed both to the new skill.

- **New Features**
  - Added `agents/skills/missing-tools/SKILL.md` with the fallback order: `direnv exec .`, `,` (comma), `nix run`, `nix shell`, plus “no global installs” and fish wrapping notes.

- **Refactors**
  - Replaced detailed sections in `claude/rules/tools.md` and `codex/AGENTS.md` with a pointer to the `missing-tools` skill.

<sup>Written for commit 4fecdd4c5fac3501bc5fd3d65cfd910487411e20. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/4501?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance and workflow for resolving missing CLI tools.
  * Updated tool usage documentation across resources to reference the new missing-tools skill.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/dotfiles/pull/4501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->