### PR TITLE
feat(nvim): resolve tsgo LSP from PATH with nixpkgs fallback

### DIFF
--- a/nvim/after/lsp/tsgo.lua
+++ b/nvim/after/lsp/tsgo.lua
@@ -1,5 +1,35 @@
+--- Resolve the `tsgo` command for a given project root.
+---
+--- Resolution order:
+--- 1. Project-local install at `<root>/node_modules/.bin/tsgo`.
+--- 2. Global `tsgo` on PATH.
+--- 3. `nix run nixpkgs#typescript-go` as a fallback, so tsgo works even on
+---    machines where it is not installed, without polluting PATH.
+---@param root string|nil project root directory
+---@return string[] cmd argv used to spawn the language server
+local function resolve_cmd(root)
+	-- 1. Prefer a project-local install when present.
+	if root then
+		local local_bin = vim.fs.joinpath(root, "node_modules/.bin", "tsgo")
+		if vim.fn.executable(local_bin) == 1 then
+			return { local_bin, "--lsp", "--stdio" }
+		end
+	end
+
+	-- 2. Use a globally installed tsgo on PATH.
+	if vim.fn.executable("tsgo") == 1 then
+		return { "tsgo", "--lsp", "--stdio" }
+	end
+
+	-- 3. Fall back to the nixpkgs build when tsgo is not installed.
+	return { "nix", "run", "nixpkgs#typescript-go", "--", "--lsp", "--stdio" }
+end
+
 ---@type vim.lsp.Config
 return {
 	single_file_support = false,
 	workspace_required = true,
+	cmd = function(dispatchers, config)
+		return vim.lsp.rpc.start(resolve_cmd((config or {}).root_dir), dispatchers)
+	end,
 }


### PR DESCRIPTION
Resolves the `tsgo` language server binary in a predictable order instead of relying solely on Neovim's launch-time PATH:

1. Project-local install at `<root>/node_modules/.bin/tsgo`
2. Global `tsgo` on PATH
3. `nix run nixpkgs#typescript-go` as a fallback, so tsgo works on machines where it is not installed, without polluting PATH

This keeps tsgo working across projects and machines while preferring a project-pinned version when available. `nixpkgs#typescript-go` provides the `tsgo` binary (verified locally).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the `tsgo` language server in a predictable order with a `nix` fallback. This keeps LSP running across machines and prefers project-pinned versions without touching PATH.

- **New Features**
  - Resolution order: `<root>/node_modules/.bin/tsgo`, `tsgo` on PATH, then `nix run nixpkgs#typescript-go`.
  - Overrides the LSP `cmd` to start with the resolved command.

<sup>Written for commit 6ef2a19de2af2d142adf09e04dc84f74b0984c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/4617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript/Go language server initialization with enhanced flexibility. The server can now launch from local project installations, global system paths, or fallback methods, eliminating the requirement for system-wide installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->