### PR TITLE
chore(agent-skills): update agent-browser and fix rewriteCommands regression

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "agent-browser-skill": {
       "flake": false,
       "locked": {
-        "lastModified": 1780683647,
-        "narHash": "sha256-MaN0yoOyRuNhv+e6//1QtEwH7C5dXGu2s+OdCowYf4I=",
+        "lastModified": 1781305250,
+        "narHash": "sha256-XDTGYcDodP4hQ7fx3dAV2FYhHKIqLuiGz6+gPfgp8Rg=",
         "owner": "vercel-labs",
         "repo": "agent-browser",
-        "rev": "328ce8a98560ac7bac8fa81f53a718822550b94e",
+        "rev": "2c7991c9eccca1c9db6eee1a26a713414778de5a",
         "type": "github"
       },
       "original": {

--- a/nix/modules/home/agent-skills.nix
+++ b/nix/modules/home/agent-skills.nix
@@ -52,6 +52,11 @@
         from = "ast-grep";
         path = "ast-grep";
         packages = [ pkgs.ast-grep ];
+        # Opt out of auto command rewriting: this skill rewrites bare names to
+        # absolute Nix store paths via transform below, not to ./name. Leaving
+        # rewriteCommands on would mangle the frontmatter name and prose, and
+        # double-prefix command paths (.//nix/store/...).
+        rewriteCommands = false;
         transform =
           { original, dependencies }:
           let
@@ -81,6 +86,9 @@
         from = "agent-browser";
         path = "agent-browser";
         packages = [ pkgs.llm-agents.agent-browser ];
+        # Opt out of auto command rewriting: this skill rewrites bare names to
+        # an absolute path under ~/.agents via transform below, not to ./name.
+        rewriteCommands = false;
         transform =
           { original, ... }:
           builtins.replaceStrings


### PR DESCRIPTION
## Summary

Updates `agent-browser-skill` and fixes a latent regression introduced by the `rewriteCommands` option (now defaulting to `true` in agent-skills-nix), which would have broken the `ast-grep` and `agent-browser` skills on the next `switch`.

## What changed

- **`flake.lock`**: bump `agent-browser-skill` `0.27.1` → `0.27.3` (click-interception detection, warm-command latency cut to ~1ms, Windows ARM64 x64 binary fallback).
- **`agent-skills.nix`**: set `rewriteCommands = false` on the `ast-grep` and `agent-browser` explicit skills.

## Why

agent-skills-nix now defaults `rewriteCommands` to `true`, which blindly rewrites bare binary names to `./name` across the entire SKILL.md (no word boundaries). Both skills instead rewrite bare names to **absolute paths** via their own `transform`, so the default:

- mangled the frontmatter name → `name: ./ast-grep`, `name: ./agent-browser`
- rewrote prose and URLs (e.g. `github.com/ast-grep` → `github.com/./ast-grep`)
- double-prefixed command paths → `.//nix/store/...`, `Bash(./agent-browser:*)`

Opting these two skills out keeps their absolute-path rewrites intact.

## Testing

- `nix run .#build` succeeds.
- Inspected the generated `SKILL.md` for both skills: frontmatter `name` is correct, zero `.//` double-prefixes, absolute store/`~/.agents` paths expand correctly (21 / 10 occurrences).
- Applied via `nix run .#switch` (run by the pre-commit hook).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `agent-browser-skill` to 0.27.3 and disable auto command rewriting for `ast-grep` and `agent-browser` to prevent SKILL.md mangling and double-prefixed paths. This keeps absolute path transforms intact and avoids breakage on the next switch.

- **Dependencies**
  - Bumped `agent-browser-skill` 0.27.1 → 0.27.3 (adds click-interception detection, ~1ms warm-command latency, Windows ARM64 x64 fallback).

- **Bug Fixes**
  - Set `rewriteCommands = false` for `ast-grep` and `agent-browser` in `agent-skills.nix` to avoid rewriting bare names to `./name`, which broke frontmatter, prose/URLs, and produced `.//` path prefixes.

<sup>Written for commit e46368958e0c5d97565860eac8eecf085024aed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/4677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command execution in `ast-grep` and `agent-browser` agent skills by disabling automatic command rewriting. This ensures custom transforms properly handle command-to-path conversions without conflicts, providing more reliable and predictable command behavior across these agent skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->