### PR TITLE
refactor(nvim): replace rustaceanvim with a native rust_analyzer config

### DIFF
--- a/nvim/after/lsp/rust_analyzer.lua
+++ b/nvim/after/lsp/rust_analyzer.lua
@@ -1,0 +1,26 @@
+--- Resolve the `rust-analyzer` command.
+---
+--- Resolution order:
+--- 1. `rust-analyzer` on PATH (e.g. from a project dev shell or rustup).
+--- 2. `nix run nixpkgs#rust-analyzer` as a fallback, so Rust LSP works even
+---    in projects whose toolchain does not ship rust-analyzer (e.g. a
+---    rust-toolchain.toml without the rust-analyzer component).
+---@return string[] cmd argv used to spawn the language server
+local function resolve_cmd()
+	if vim.fn.executable("rust-analyzer") == 1 then
+		return { "rust-analyzer" }
+	end
+	return { "nix", "run", "nixpkgs#rust-analyzer" }
+end
+
+---@type vim.lsp.Config
+return {
+	cmd = resolve_cmd(),
+	settings = {
+		["rust-analyzer"] = {
+			check = {
+				command = "clippy",
+			},
+		},
+	},
+}

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -99,7 +99,6 @@
   "quick-scope": { "branch": "master", "commit": "6cee1d9e0b9ac0fbffeb538d4a5ba9f5628fabbc" },
   "quicker.nvim": { "branch": "master", "commit": "063cc44da1eef8681bbd653b29d3bc961780886a" },
   "rainbow-delimiters.nvim": { "branch": "master", "commit": "08783ec022e7ddefe0f12a16f1ac4968f55478b0" },
-  "rustaceanvim": { "branch": "main", "commit": "e9c5aaba16fead831379d5f44617547a90b913c7" },
   "satellite.nvim": { "branch": "main", "commit": "62b0aa1a941e35e694e8a50b589150bcca8c084d" },
   "schemastore.nvim": { "branch": "main", "commit": "20d4e9970798123e6197acb1c85c4b1e897efd29" },
   "snacks.nvim": { "branch": "main", "commit": "ad9ede6a9cddf16cedbd31b8932d6dcdee9b716e" },

--- a/nvim/lua/plugin/nvim-lspconfig/init.lua
+++ b/nvim/lua/plugin/nvim-lspconfig/init.lua
@@ -47,6 +47,9 @@ return {
 				-- go
 				"gopls",
 
+				-- rust
+				"rust_analyzer",
+
 				-- lua
 				"lua_ls",
 

--- a/nvim/lua/plugin/rustaceanvim.lua
+++ b/nvim/lua/plugin/rustaceanvim.lua
@@ -1,6 +1,0 @@
-return {
-	"mrcjkb/rustaceanvim",
-	cond = not is_vscode(),
-	version = "^5",
-	lazy = false,
-}


### PR DESCRIPTION
rustaceanvim was pinned to ^5 (four majors behind) and loaded with lazy = false on every start, yet Rust LSP could not actually work: rust-analyzer is neither on the global PATH nor shipped by the ccusage dev shell toolchain, and no Rust file has been opened in Neovim's recorded history. Its extras (DAP integration, :RustLsp runnables) are unused — DAP was removed from this config long ago.

Every other language here is configured through the native vim.lsp.enable + after/lsp pattern, so bring Rust in line with that: a plain rust_analyzer config that prefers a PATH-provided binary and falls back to nix run nixpkgs#rust-analyzer (mirroring the tsgo config), with clippy as the check-on-save command.

crates.nvim stays for Cargo.toml dependency management.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `rustaceanvim` with a native `rust_analyzer` LSP config that prefers a PATH binary and falls back to `nix run nixpkgs#rust-analyzer`. Rust LSP now works by default and runs clippy on save.

- **Refactors**
  - Added `nvim/after/lsp/rust_analyzer.lua` with command resolution and `check.command = "clippy"`.
  - Enabled `rust_analyzer` in `nvim-lspconfig`; removed `rustaceanvim` and its lock entry.
  - Kept `crates.nvim` for `Cargo.toml` dependency management.

<sup>Written for commit 5db943edc14570d53cf74db2986f91c7b71cd91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/4986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

