### PR TITLE
refactor(ci): rewrite the long workflow scripts in Nushell

### DIFF
--- a/.github/actions/discover-flake-inputs/action.yaml
+++ b/.github/actions/discover-flake-inputs/action.yaml
@@ -26,130 +26,93 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+      with:
+        version: '0.114.1'
+
     - name: Discover flake inputs
       id: discover
-      shell: bash
+      shell: nu {0}
       env:
         INPUTS: ${{ inputs.inputs }}
         EXCLUDE_INPUTS: ${{ inputs.exclude-inputs }}
         SKIP_DELAY_INPUTS: ${{ inputs.skip-delay-inputs }}
       run: |
-        set -euo pipefail
-
-        echo "=== Discovery Configuration ==="
-        echo "INPUTS: ${INPUTS:-<all>}"
-        echo "Exclude inputs: ${EXCLUDE_INPUTS:-<none>}"
-        echo "Skip delay inputs: ${SKIP_DELAY_INPUTS:-<none>}"
-        echo
-
-        # Convert exclude inputs to array
-        IFS=' ' read -ra exclude_array <<< "${EXCLUDE_INPUTS:-}"
-
-        # Convert skip delay inputs to array
-        IFS=' ' read -ra skip_delay_array <<< "${SKIP_DELAY_INPUTS:-}"
-
-        # Function to check if input should be excluded
-        should_exclude() {
-          local input="$1"
-          for exclude_input in "${exclude_array[@]}"; do
-            if [ "$input" = "$exclude_input" ]; then
-              return 0
-            fi
-          done
-          return 1
+        def parse-list [raw: string]: nothing -> list<string> {
+          $raw | split row -r '\s+' | where { |item| $item | is-not-empty }
         }
 
-        # Function to check if input should skip delay
-        should_skip_delay() {
-          local input="$1"
-          for skip_input in "${skip_delay_array[@]}"; do
-            if [ "$input" = "$skip_input" ]; then
-              return 0
-            fi
-          done
-          return 1
+        def describe-list [items: list<string>, empty_label: string]: nothing -> string {
+          match $items {
+            [] => $empty_label
+            $names => ($names | str join ' ')
+          }
         }
 
-        # Initialise array for matrix items
-        declare -a matrix_items=()
+        def github-output [outputs: record] {
+          $outputs | items { |key, value| $"($key)=($value)\n" } | str join | save --append $env.GITHUB_OUTPUT
+        }
 
-        echo "Discovering flake inputs..."
+        # Matrix entry consumed by the update job. `ref` stays empty for inputs that
+        # follow their default branch, and the short revision is what PR titles show.
+        def matrix-entry [name: string, node: record, skip_delay: bool]: nothing -> record {
+          {
+            name: $name
+            current_version: ($node.locked.rev? | default 'unknown' | str substring ..<8)
+            skip_delay: $skip_delay
+            owner: ($node.original.owner? | default 'unknown')
+            repo: ($node.original.repo? | default 'unknown')
+            ref: ($node.original.ref? | default '')
+          }
+        }
 
-        if [ ! -f "flake.lock" ]; then
-          echo "No flake.lock found"
-          echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
-          echo "has-updates=false" >> "$GITHUB_OUTPUT"
+        let requested = (parse-list $env.INPUTS)
+        let excluded = (parse-list $env.EXCLUDE_INPUTS)
+        let skip_delay = (parse-list $env.SKIP_DELAY_INPUTS)
+
+        print '=== Discovery configuration ==='
+        print $"Inputs: (describe-list $requested '<all>')"
+        print $"Excluded: (describe-list $excluded '<none>')"
+        print $"Skip delay: (describe-list $skip_delay '<none>')"
+
+        if not ('flake.lock' | path exists) {
+          print 'No flake.lock found'
+          github-output { matrix: ({ include: [] } | to json --raw), has-updates: false }
           exit 0
-        fi
+        }
 
-        # Get flake metadata
-        if ! metadata=$(nix flake metadata --json --no-write-lock-file 2>/dev/null); then
-          echo "Failed to get flake metadata"
-          exit 1
-        fi
+        let nodes = (nix flake metadata --json --no-write-lock-file | from json | get locks.nodes)
+        # Only root inputs are candidates; every other node in the lock file is a
+        # transitive dependency that follows its parent.
+        let names = match $requested {
+          [] => ($nodes.root.inputs | columns | sort)
+          $inputs => $inputs
+        }
 
-        if [ -n "$INPUTS" ]; then
-          requested_inputs="$INPUTS"
-        else
-          # Get all direct inputs (not transitive dependencies)
-          requested_inputs=$(echo "$metadata" | jq -r '.locks.nodes.root.inputs | keys[]' | sort)
-        fi
+        let candidates = (
+          $names
+          | each { |name|
+            match [($name in $excluded) ($nodes | get -o $name)] {
+              [true, _] => { name: $name, state: 'excluded' }
+              [_, null] => { name: $name, state: 'missing' }
+              [_, $node] => { name: $name, state: 'included', entry: (matrix-entry $name $node ($name in $skip_delay)) }
+            }
+          }
+        )
 
-        for input in $requested_inputs; do
-          # Check if this input should be excluded
-          if [ ${#exclude_array[@]} -gt 0 ] && should_exclude "$input"; then
-            echo "  - $input (excluded)"
-            continue
-          fi
+        print '=== Discovery results ==='
+        for candidate in $candidates {
+          match $candidate.state {
+            'excluded' => (print $"  - ($candidate.name) \(excluded)")
+            'missing' => (print $"  - ($candidate.name) \(not in flake.lock, skipped)")
+            _ => (print $"  - ($candidate.name) ($candidate.entry | reject name | to json --raw)")
+          }
+        }
 
-          # Check if this input exists in the flake
-          if ! echo "$metadata" | jq -e ".locks.nodes.\"$input\"" >/dev/null 2>&1; then
-            echo "Warning: Input $input not found, skipping"
-            continue
-          fi
+        let entries = ($candidates | where state == 'included' | each { |candidate| $candidate.entry })
+        print $"($entries | length) input\(s) to check"
 
-          current_rev=$(echo "$metadata" | jq -r ".locks.nodes.\"$input\".locked.rev // \"unknown\"" | head -c 8)
-          owner=$(echo "$metadata" | jq -r ".locks.nodes.\"$input\".original.owner // \"unknown\"")
-          repo=$(echo "$metadata" | jq -r ".locks.nodes.\"$input\".original.repo // \"unknown\"")
-          ref=$(echo "$metadata" | jq -r ".locks.nodes.\"$input\".original.ref // \"\"")
-
-          # Determine if this input should skip delay
-          if should_skip_delay "$input"; then
-            skip_delay="true"
-          else
-            skip_delay="false"
-          fi
-
-          matrix_items+=("{\"name\":\"$input\",\"current_version\":\"$current_rev\",\"skip_delay\":$skip_delay,\"owner\":\"$owner\",\"repo\":\"$repo\",\"ref\":\"$ref\"}")
-          if [ -n "$ref" ]; then
-            echo "  - $input ($current_rev) [skip_delay=$skip_delay, ref=$ref]"
-          else
-            echo "  - $input ($current_rev) [skip_delay=$skip_delay]"
-          fi
-        done
-
-        echo
-        echo "=== Discovery Results ==="
-
-        # Create matrix JSON
-        if [ ${#matrix_items[@]} -eq 0 ]; then
-          matrix='{"include":[]}'
-          has_updates="false"
-          echo "No items to update"
-        else
-          matrix_json='{"include":['
-          for i in "${!matrix_items[@]}"; do
-            if [ "$i" -gt 0 ]; then
-              matrix_json+=","
-            fi
-            matrix_json+="${matrix_items[$i]}"
-          done
-          matrix_json+="]}"
-
-          matrix="$matrix_json"
-          has_updates="true"
-          echo "Found ${#matrix_items[@]} input(s) to check"
-        fi
-
-        echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-        echo "has-updates=$has_updates" >> "$GITHUB_OUTPUT"
+        github-output {
+          matrix: ({ include: $entries } | to json --raw)
+          has-updates: ($entries | is-not-empty)
+        }

--- a/.github/actions/update-flake-input/action.yaml
+++ b/.github/actions/update-flake-input/action.yaml
@@ -54,9 +54,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+      with:
+        version: '0.114.1'
+
     - name: Update flake input
       id: update
-      shell: bash
+      shell: nu {0}
       env:
         INPUT_NAME: ${{ inputs.input-name }}
         INPUT_OWNER: ${{ inputs.owner }}
@@ -66,239 +70,200 @@ runs:
         MIN_AGE_DAYS: ${{ inputs.minimum-release-age-days }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        set -euo pipefail
-
-        echo "=== Updating input: $INPUT_NAME ==="
-        echo "Skip delay: $SKIP_DELAY"
-        echo "Minimum release age: $MIN_AGE_DAYS days"
-
-        # Calculate minimum age in seconds
-        min_age_seconds=$((MIN_AGE_DAYS * 86400))
-
-        # Get current revision before update
-        current_metadata=$(nix flake metadata --json --no-write-lock-file 2>/dev/null)
-        current_rev=$(echo "$current_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.rev // \"unknown\"")
-        current_owner=$(echo "$current_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.owner // \"unknown\"")
-        current_repo=$(echo "$current_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.repo // \"unknown\"")
-        echo "Current revision: $current_rev"
-
-        # Function to get package versions from a flake
-        get_package_versions() {
-          local flake_ref="$1"
-          local packages=""
-
-          # Define packages to check for each input
-          case "$INPUT_NAME" in
-            llm-agents)
-              packages="claude-code codex cursor-agent gemini-cli opencode goose-cli"
-              ;;
-            nix-bun)
-              packages="bun"
-              ;;
-            *)
-              echo ""
-              return
-              ;;
-          esac
-
-          local versions=""
-          for pkg in $packages; do
-            local version
-            version=$(nix eval --raw "${flake_ref}#packages.x86_64-linux.${pkg}.version" 2>/dev/null || echo "")
-            if [ -n "$version" ]; then
-              if [ -n "$versions" ]; then
-                versions="${versions}, ${pkg}=${version}"
-              else
-                versions="${pkg}=${version}"
-              fi
-            fi
-          done
-          echo "$versions"
+        const GITHUB_DATE = '%Y-%m-%dT%H:%M:%SZ'
+        # Packages worth naming in the PR title; other inputs get no version details.
+        const TRACKED_PACKAGES = {
+          llm-agents: [claude-code codex cursor-agent gemini-cli opencode goose-cli]
+          nix-bun: [bun]
         }
 
-        # Get current package versions for special inputs
-        current_pkg_versions=""
-        if [ "$INPUT_NAME" = "llm-agents" ] || [ "$INPUT_NAME" = "nix-bun" ]; then
-          echo "Fetching current package versions..."
-          current_pkg_versions=$(get_package_versions "github:${current_owner}/${current_repo}/${current_rev}")
-          echo "Current package versions: $current_pkg_versions"
-        fi
+        def github-output [outputs: record] {
+          $outputs | items { |key, value| $"($key)=($value)\n" } | str join | save --append $env.GITHUB_OUTPUT
+        }
 
-        # Determine target revision for update
-        target_rev=""
-        if [ "$SKIP_DELAY" = "false" ] && [ -n "$INPUT_OWNER" ] && [ -n "$INPUT_REPO" ]; then
-          echo "Fetching commit from at least $MIN_AGE_DAYS days ago via GitHub API..."
+        # The `locked` fields of an input as flake.lock currently records them.
+        def locked-input [name: string]: nothing -> record {
+          nix flake metadata --json --no-write-lock-file
+          | from json
+          | get locks.nodes
+          | get -o $name
+          | default {}
+          | get -o locked
+          | default {}
+        }
 
-          # Calculate the cutoff date
-          cutoff_date=$(date -u -d "$MIN_AGE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-                        date -u -v-${MIN_AGE_DAYS}d +%Y-%m-%dT%H:%M:%SZ)
-          echo "Cutoff date: $cutoff_date"
+        def flake-ref [locked: record]: nothing -> string {
+          $"github:($locked.owner? | default '')/($locked.repo? | default '')/($locked.rev? | default '')"
+        }
 
-          # Build the API URL with optional branch filter
-          api_url="repos/${INPUT_OWNER}/${INPUT_REPO}/commits?until=${cutoff_date}&per_page=1"
-          if [ -n "$INPUT_REF" ]; then
-            api_url="${api_url}&sha=${INPUT_REF}"
-            echo "Filtering by branch: $INPUT_REF"
-          fi
+        # An input may drop or rename a package, so a failed eval means "not exposed
+        # by this revision" rather than an error worth stopping for.
+        def package-version [flake_ref: string, package: string]: nothing -> string {
+          try { nix eval --raw $"($flake_ref)#packages.x86_64-linux.($package).version" } catch { '' }
+        }
 
-          # Fetch the most recent commit that is at least MIN_AGE_DAYS old
-          if commit_data=$(gh api "$api_url" --jq '.[0] | {sha: .sha, date: .commit.committer.date}' 2>/dev/null); then
-            target_rev=$(echo "$commit_data" | jq -r '.sha // empty')
-            commit_date=$(echo "$commit_data" | jq -r '.date // empty')
+        # Package name -> version for every tracked package the flake ref exposes.
+        def package-versions [flake_ref: string, packages: list<string>]: nothing -> record {
+          $packages
+          | each { |package| { name: $package, version: (package-version $flake_ref $package) } }
+          | where { |entry| $entry.version | is-not-empty }
+          | reduce --fold {} { |entry, versions| $versions | insert $entry.name $entry.version }
+        }
 
-            if [ -n "$target_rev" ]; then
-              echo "Found commit from $commit_date: ${target_rev:0:8}"
+        # Packages that moved to another version. Packages that exist on only one
+        # side are left out because there is no before/after pair to report.
+        def render-version-diff [before: record, after: record]: nothing -> string {
+          $after
+          | items { |package, version| { package: $package, before: ($before | get -o $package), after: $version } }
+          | where { |change| $change.before != null and $change.before != $change.after }
+          | each { |change| $"($change.package) ($change.before) → ($change.after)" }
+          | str join ', '
+        }
 
-              # Check if this is the same as current revision
-              if [ "${target_rev:0:40}" = "${current_rev:0:40}" ]; then
-                echo "Target revision is the same as current. No update needed."
-                echo "updated=false" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
+        # flake.lock stores lastModified in Unix seconds, but `into datetime` reads
+        # plain integers as nanoseconds.
+        def from-unix [seconds: int]: nothing -> datetime {
+          ($seconds * 1_000_000_000) | into datetime
+        }
 
-              # Check if target is older than current (would be a downgrade)
-              if [ -n "$current_rev" ] && [ "$current_rev" != "unknown" ]; then
-                current_commit_date=$(gh api "repos/${INPUT_OWNER}/${INPUT_REPO}/commits/${current_rev}" --jq '.commit.committer.date' 2>/dev/null || echo "")
-                if [ -n "$current_commit_date" ] && [ -n "$commit_date" ]; then
-                  current_ts=$(date -d "$current_commit_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$current_commit_date" +%s 2>/dev/null || echo "0")
-                  target_ts=$(date -d "$commit_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$commit_date" +%s 2>/dev/null || echo "0")
-                  if [ "$target_ts" -lt "$current_ts" ]; then
-                    echo "Target revision (${target_rev:0:8} from $commit_date) is older than current (${current_rev:0:8} from $current_commit_date). Skipping to avoid downgrade."
-                    echo "updated=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-                fi
-              fi
-            else
-              echo "No commits found older than $MIN_AGE_DAYS days. Skipping update."
-              echo "updated=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          else
-            echo "Warning: Failed to fetch commits via GitHub API, falling back to standard update"
-          fi
-        fi
+        # The GitHub API expects UTC, and `format date` would otherwise render local
+        # time under a `Z` suffix.
+        def utc-timestamp [moment: datetime]: nothing -> string {
+          $moment | date to-timezone UTC | format date $GITHUB_DATE
+        }
 
-        # Perform the update
-        if [ -n "$target_rev" ]; then
-          # Update to specific revision
-          echo "Running: nix flake update $INPUT_NAME --override-input $INPUT_NAME github:${INPUT_OWNER}/${INPUT_REPO}/${target_rev}"
-          if ! nix flake update "$INPUT_NAME" --override-input "$INPUT_NAME" "github:${INPUT_OWNER}/${INPUT_REPO}/${target_rev}"; then
-            echo "::error::Failed to update $INPUT_NAME to specific revision"
-            exit 1
-          fi
-        else
-          # Standard update (latest)
-          echo "Running: nix flake update $INPUT_NAME"
-          if ! nix flake update "$INPUT_NAME"; then
-            echo "::error::Failed to update $INPUT_NAME"
-            exit 1
-          fi
-        fi
+        # `git diff --quiet` exits 1 when the path differs, which Nushell surfaces as
+        # a command failure, so the exit code has to be inspected instead of raised.
+        def has-changes [path: string]: nothing -> bool {
+          (git diff --quiet -- $path | complete | get exit_code) != 0
+        }
 
-        # Check if there were actual changes
-        if git diff --quiet flake.lock; then
-          echo "No changes detected for $INPUT_NAME"
-          echo "updated=false" >> "$GITHUB_OUTPUT"
+        # Newest commit that is already older than the release-age window. A failing
+        # API call is reported as `unavailable` so the caller can fall back to a plain
+        # update, which differs from the repository having no commit that old.
+        def aged-commit [owner: string, repo: string, git_ref: string, cutoff: datetime]: nothing -> record {
+          let query = { until: (utc-timestamp $cutoff), per_page: 1 }
+            | merge (if ($git_ref | is-empty) { {} } else { { sha: $git_ref } })
+            | items { |key, value| $"($key)=($value)" }
+            | str join '&'
+          let commits = try { gh api $"repos/($owner)/($repo)/commits?($query)" | from json } catch { null }
+
+          match $commits {
+            null => { status: 'unavailable' }
+            [] => { status: 'none' }
+            [$commit, ..] => {
+              { status: 'found', sha: $commit.sha, date: ($commit.commit.committer.date | into datetime) }
+            }
+          }
+        }
+
+        # When a revision was committed, or null when the API cannot tell us.
+        def commit-date [owner: string, repo: string, rev: string] {
+          try {
+            gh api $"repos/($owner)/($repo)/commits/($rev)" | from json | get commit.committer.date | into datetime
+          } catch {
+            null
+          }
+        }
+
+        # Report "nothing to do" and stop, leaving flake.lock as it was found.
+        def skip [reason: string] {
+          print $reason
+          github-output { updated: false }
           exit 0
-        fi
+        }
 
-        # Get new revision info
-        new_metadata=$(nix flake metadata --json --no-write-lock-file 2>/dev/null)
-        new_rev=$(echo "$new_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.rev // \"unknown\"")
-        new_owner=$(echo "$new_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.owner // \"unknown\"")
-        new_repo=$(echo "$new_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.repo // \"unknown\"")
-        echo "New revision: $new_rev"
+        let name = $env.INPUT_NAME
+        let owner = $env.INPUT_OWNER
+        let repo = $env.INPUT_REPO
+        let skip_delay = ($env.SKIP_DELAY == 'true')
+        let min_age = (($env.MIN_AGE_DAYS | into int) * 1day)
+        let packages = ($TRACKED_PACKAGES | get -o $name | default [])
+        let before = (locked-input $name)
 
-        # Get new package versions for special inputs
-        new_pkg_versions=""
-        pkg_version_diff=""
-        if [ "$INPUT_NAME" = "llm-agents" ] || [ "$INPUT_NAME" = "nix-bun" ]; then
-          echo "Fetching new package versions..."
-          new_pkg_versions=$(get_package_versions "github:${new_owner}/${new_repo}/${new_rev}")
-          echo "New package versions: $new_pkg_versions"
+        print $"=== Updating input: ($name) ==="
+        print $"Current revision: ($before.rev? | default 'unknown')"
+        print (match $skip_delay {
+          true => 'Release age check: skipped'
+          false => $"Minimum release age: ($min_age)"
+        })
 
-          # Build version diff for changed packages
-          if [ -n "$current_pkg_versions" ] && [ -n "$new_pkg_versions" ]; then
-            # Parse and compare versions
-            declare -A old_versions new_versions
-            IFS=', ' read -ra old_pairs <<< "$current_pkg_versions"
-            for pair in "${old_pairs[@]}"; do
-              key="${pair%%=*}"
-              val="${pair#*=}"
-              old_versions["$key"]="$val"
-            done
-            IFS=', ' read -ra new_pairs <<< "$new_pkg_versions"
-            for pair in "${new_pairs[@]}"; do
-              key="${pair%%=*}"
-              val="${pair#*=}"
-              new_versions["$key"]="$val"
-            done
+        let versions_before = (package-versions (flake-ref $before) $packages)
+        if ($packages | is-not-empty) { print $"Current package versions: ($versions_before)" }
 
-            # Find changed versions
-            changed_pkgs=""
-            for key in "${!new_versions[@]}"; do
-              old_val="${old_versions[$key]:-}"
-              new_val="${new_versions[$key]}"
-              if [ "$old_val" != "$new_val" ] && [ -n "$old_val" ]; then
-                if [ -n "$changed_pkgs" ]; then
-                  changed_pkgs="${changed_pkgs}, ${key} ${old_val} → ${new_val}"
-                else
-                  changed_pkgs="${key} ${old_val} → ${new_val}"
-                fi
-              fi
-            done
+        # Resolving the target revision up front keeps a too-new commit out of
+        # flake.lock, rather than writing it and reverting afterwards.
+        let target = if $skip_delay or ($owner | is-empty) or ($repo | is-empty) {
+          { status: 'skipped' }
+        } else {
+          aged-commit $owner $repo $env.INPUT_REF ((date now) - $min_age)
+        }
 
-            if [ -n "$changed_pkgs" ]; then
-              pkg_version_diff="$changed_pkgs"
-              echo "Package version changes: $pkg_version_diff"
-            fi
-          fi
-        fi
+        match $target.status {
+          'none' => (skip $"No commit older than ($min_age) found. Skipping update.")
+          'unavailable' => (print '::warning::Could not query commits; falling back to the latest revision')
+          'found' => {
+            print $"Target revision: ($target.sha | str substring ..<8) from (utc-timestamp $target.date)"
+            if $target.sha == ($before.rev? | default '') {
+              skip 'Target revision matches the current one. No update needed.'
+            }
+            let before_date = (commit-date $owner $repo ($before.rev? | default ''))
+            if $before_date != null and $target.date < $before_date {
+              skip $"Target revision predates the current one \((utc-timestamp $before_date)). Skipping to avoid a downgrade."
+            }
+          }
+          _ => {}
+        }
 
-        # Verify release age for standard updates (when target_rev was not pre-determined)
-        if [ -z "$target_rev" ] && [ "$SKIP_DELAY" = "false" ]; then
-          echo "Verifying release age (minimum: $MIN_AGE_DAYS days)..."
+        let target_sha = if $target.status == 'found' { $target.sha } else { null }
+        try {
+          match $target_sha {
+            null => { nix flake update $name }
+            $sha => { nix flake update $name --override-input $name $"github:($owner)/($repo)/($sha)" }
+          }
+        } catch {
+          print $"::error::Failed to update ($name)"
+          exit 1
+        }
 
-          last_modified=$(echo "$new_metadata" | jq -r ".locks.nodes.\"$INPUT_NAME\".locked.lastModified // 0")
+        if not (has-changes 'flake.lock') { skip $"No changes detected for ($name)" }
 
-          if [ "$last_modified" != "0" ] && [ "$last_modified" != "null" ]; then
-            current_time=$(date +%s)
-            age_seconds=$((current_time - last_modified))
-            age_days=$((age_seconds / 86400))
+        let after = (locked-input $name)
+        print $"New revision: ($after.rev? | default 'unknown')"
 
-            echo "Release age: $age_days days ($age_seconds seconds)"
+        # A plain update lands on whatever HEAD is, so its age can only be checked
+        # once the new revision is in the lock file.
+        if $target_sha == null and not $skip_delay {
+          match ($after.lastModified? | default 0) {
+            0 => (print '::warning::Could not determine lastModified; keeping the update')
+            $seconds => {
+              let age = ((date now) - (from-unix $seconds))
+              print $"Release age: ($age)"
+              if $age < $min_age {
+                git checkout flake.lock
+                skip $"Release is younger than ($min_age). Skipping update."
+              }
+            }
+          }
+        }
 
-            if [ "$age_seconds" -lt "$min_age_seconds" ]; then
-              echo "Release is too new (less than $MIN_AGE_DAYS days old). Skipping update."
-              git checkout flake.lock
-              echo "updated=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+        let versions_after = (package-versions (flake-ref $after) $packages)
+        let version_diff = (render-version-diff $versions_before $versions_after)
+        if ($version_diff | is-not-empty) { print $"Package version changes: ($version_diff)" }
 
-            echo "Release age check passed (>= $MIN_AGE_DAYS days old)"
-          else
-            echo "Warning: Could not determine lastModified timestamp, proceeding with update"
-          fi
-        else
-          if [ -n "$target_rev" ]; then
-            echo "Update to pre-validated revision (>= $MIN_AGE_DAYS days old)"
-          else
-            echo "Skipping release age check (skip_delay=true)"
-          fi
-        fi
-
-        echo "Update successful!"
-        echo "updated=true" >> "$GITHUB_OUTPUT"
-        echo "new_version=${new_rev:0:8}" >> "$GITHUB_OUTPUT"
-        echo "current_pkg_versions=${current_pkg_versions}" >> "$GITHUB_OUTPUT"
-        echo "new_pkg_versions=${new_pkg_versions}" >> "$GITHUB_OUTPUT"
-        echo "pkg_version_diff=${pkg_version_diff}" >> "$GITHUB_OUTPUT"
+        github-output {
+          updated: true
+          new_version: ($after.rev? | default 'unknown' | str substring ..<8)
+          current_pkg_versions: ($versions_before | to json --raw)
+          new_pkg_versions: ($versions_after | to json --raw)
+          pkg_version_diff: $version_diff
+        }
+        print 'Update successful!'
 
     - name: Create pull request
       id: create-pr
       if: steps.update.outputs.updated == 'true'
-      shell: bash
+      shell: nu {0}
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_NAME: ${{ inputs.input-name }}
@@ -312,126 +277,83 @@ runs:
         NEW_PKG_VERSIONS: ${{ steps.update.outputs.new_pkg_versions }}
         PKG_VERSION_DIFF: ${{ steps.update.outputs.pkg_version_diff }}
       run: |
-        set -euo pipefail
+        # Step outputs arrive as strings; an empty value means no packages are tracked.
+        def parse-versions [raw: string]: nothing -> record {
+          if ($raw | is-empty) { {} } else { $raw | from json }
+        }
 
-        branch="update-flake-${INPUT_NAME}"
+        # Markdown rows comparing every known package version before and after.
+        def version-rows [before: record, after: record]: nothing -> list<string> {
+          $after
+          | items { |package, version|
+            let previous = ($before | get -o $package | default 'N/A')
+            let marker = if $previous == $version { '' } else { ' :arrow_up:' }
+            $"| ($package) | `($previous)` | `($version)`($marker) |"
+          }
+        }
 
-        # Build PR title with package version diff if available
-        if [ -n "$PKG_VERSION_DIFF" ]; then
-          pr_title="chore(nix): update ${INPUT_NAME} (${PKG_VERSION_DIFF})"
-        else
-          pr_title="chore(nix): update flake input ${INPUT_NAME} to ${NEW_VERSION}"
-        fi
+        let name = $env.INPUT_NAME
+        let new_version = $env.NEW_VERSION
+        let branch = $"update-flake-($name)"
+        let rows = (version-rows (parse-versions $env.CURRENT_PKG_VERSIONS) (parse-versions $env.NEW_PKG_VERSIONS))
 
-        # Create PR body
-        if [ "$SKIP_DELAY" = "true" ]; then
-          delay_note=":zap: This input is configured to skip the release age check."
-        else
-          delay_note=":hourglass: This update passed the ${MIN_AGE_DAYS}-day minimum release age check."
-        fi
+        # Package versions say more than a revision, so they win the title whenever
+        # the update moved any of them.
+        let title = match $env.PKG_VERSION_DIFF {
+          '' => $"chore\(nix): update flake input ($name) to ($new_version)"
+          $diff => $"chore\(nix): update ($name) \(($diff))"
+        }
 
-        # Build package versions section if available
-        pkg_versions_section=""
-        if [ -n "$NEW_PKG_VERSIONS" ]; then
-          pkg_versions_section="
-        ## Package Versions
-        | Package | Old | New |
-        |---------|-----|-----|"
+        let note = match $env.SKIP_DELAY {
+          'true' => ':zap: This input is configured to skip the release age check.'
+          _ => $":hourglass: This update passed the ($env.MIN_AGE_DAYS)-day minimum release age check."
+        }
 
-          # Parse current and new versions into arrays
-          declare -A old_versions new_versions
-          if [ -n "$CURRENT_PKG_VERSIONS" ]; then
-            IFS=', ' read -ra old_pairs <<< "$CURRENT_PKG_VERSIONS"
-            for pair in "${old_pairs[@]}"; do
-              key="${pair%%=*}"
-              val="${pair#*=}"
-              old_versions["$key"]="$val"
-            done
-          fi
-          IFS=', ' read -ra new_pairs <<< "$NEW_PKG_VERSIONS"
-          for pair in "${new_pairs[@]}"; do
-            key="${pair%%=*}"
-            val="${pair#*=}"
-            new_versions["$key"]="$val"
-          done
+        let versions_section = match $rows {
+          [] => []
+          $table => ['' '## Package Versions' '' '| Package | Old | New |' '|---------|-----|-----|' ...$table]
+        }
 
-          # Build table rows
-          for key in "${!new_versions[@]}"; do
-            old_val="${old_versions[$key]:-N/A}"
-            new_val="${new_versions[$key]}"
-            if [ "$old_val" != "$new_val" ]; then
-              pkg_versions_section="${pkg_versions_section}
-        | ${key} | \`${old_val}\` | \`${new_val}\` :arrow_up: |"
-            else
-              pkg_versions_section="${pkg_versions_section}
-        | ${key} | \`${old_val}\` | \`${new_val}\` |"
-            fi
-          done
-        fi
+        let body = [
+          $"Automated update of flake input `($name)`."
+          ''
+          '## Changes'
+          $"- **($name)**: `($env.CURRENT_VERSION)` :arrow_right: `($new_version)`"
+          ...$versions_section
+          ''
+          '## Notes'
+          $note
+          ''
+          '---'
+          'This PR was automatically created by the flake update workflow.'
+        ] | str join "\n"
 
-        pr_body="Automated update of flake input \`${INPUT_NAME}\`.
-
-        ## Changes
-        - **${INPUT_NAME}**: \`${CURRENT_VERSION}\` :arrow_right: \`${NEW_VERSION}\`
-        ${pkg_versions_section}
-
-        ## Notes
-        ${delay_note}
-
-        ---
-        This PR was automatically created by the flake update workflow."
-
-        # Stage changes
         git add flake.lock
+        git checkout -b $branch
+        git commit -m $title
+        # A re-run of the same workflow reuses the branch name, so the push is forced.
+        git push --force origin $branch
 
-        # Create branch
-        git checkout -b "$branch"
+        match (gh pr list --head $branch --json number | from json | get -o 0.number) {
+          null => {
+            print $"Creating a pull request for ($branch)"
+            let label_args = ($env.PR_LABELS | split row ',' | each { |label| ['--label' ($label | str trim)] } | flatten)
+            gh pr create --title $title --body $body --base main --head $branch ...$label_args
+          }
+          $existing => {
+            print $"Updating existing PR #($existing)"
+            gh pr edit $existing --title $title --body $body
+          }
+        }
 
-        # Build commit message with package version diff if available
-        if [ -n "$PKG_VERSION_DIFF" ]; then
-          commit_message="chore(nix): update ${INPUT_NAME} (${PKG_VERSION_DIFF})"
-        else
-          commit_message="chore(nix): update flake input ${INPUT_NAME} to ${NEW_VERSION}"
-        fi
+        let number = (gh pr list --head $branch --json number | from json | get 0.number)
+        if $env.AUTO_MERGE == 'true' {
+          # Auto-merge is rejected unless the repository has branch protection configured.
+          try { gh pr merge $number --auto --squash } catch {
+            print '::warning::Could not enable auto-merge; branch protection rules may be missing'
+          }
+        }
 
-        git commit -m "$commit_message"
-
-        # Push (force to handle re-runs)
-        git push --force origin "$branch"
-
-        # Check if PR exists
-        pr_number=$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')
-
-        if [ -n "$pr_number" ]; then
-          echo "Updating existing PR #$pr_number"
-          gh pr edit "$pr_number" --title "$pr_title" --body "$pr_body"
-        else
-          echo "Creating new PR"
-
-          # Build label arguments
-          label_args=""
-          IFS=',' read -ra labels <<< "$PR_LABELS"
-          for label in "${labels[@]}"; do
-            label=$(echo "$label" | xargs)
-            label_args="$label_args --label $label"
-          done
-
-          gh pr create \
-            --title "$pr_title" \
-            --body "$pr_body" \
-            --base main \
-            --head "$branch" \
-            $label_args
-
-          pr_number=$(gh pr list --head "$branch" --json number --jq '.[0].number')
-        fi
-
-        # Enable auto-merge if requested
-        if [ "$AUTO_MERGE" = "true" ] && [ -n "$pr_number" ]; then
-          echo "Enabling auto-merge for PR #$pr_number"
-          gh pr merge "$pr_number" --auto --squash || echo "Note: Auto-merge may require branch protection rules"
-        fi
-
-        pr_url=$(gh pr view "$pr_number" --json url --jq '.url')
-        echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
-        echo "PR URL: $pr_url"
+        let url = (gh pr view $number --json url | from json | get url)
+        print $"PR URL: ($url)"
+        $"pr_url=($url)\n" | save --append $env.GITHUB_OUTPUT

--- a/.github/workflows/_update-flake-reusable.yaml
+++ b/.github/workflows/_update-flake-reusable.yaml
@@ -120,7 +120,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: always() && needs.discover.outputs.has-updates == 'true'
     steps:
+      - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+        with:
+          version: '0.114.1'
+
       - name: Generate summary
+        shell: nu {0}
         env:
           SUMMARY_TITLE: ${{ inputs.summary-title }}
           INPUTS: ${{ inputs.inputs }}
@@ -129,25 +134,35 @@ jobs:
           MINIMUM_RELEASE_AGE_DAYS: ${{ inputs.minimum-release-age-days }}
           AUTO_MERGE: ${{ inputs.auto-merge }}
           UPDATE_RESULT: ${{ needs.update.result }}
+        # This job only writes the run summary, so keeping the script inline avoids
+        # checking the repository out.
         run: |
-          echo "## $SUMMARY_TITLE" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Configuration" >> $GITHUB_STEP_SUMMARY
-          if [ -n "$INPUTS" ]; then
-            echo "- Inputs: $INPUTS" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -n "$EXCLUDE_INPUTS" ]; then
-            echo "- Excluded: $EXCLUDE_INPUTS" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -n "$SKIP_DELAY_INPUTS" ]; then
-            echo "- Skip delay: $SKIP_DELAY_INPUTS" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "- Minimum release age: $MINIMUM_RELEASE_AGE_DAYS days" >> $GITHUB_STEP_SUMMARY
-          echo "- Auto-merge: $AUTO_MERGE" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          # Configuration that was left at its default is not worth a summary line.
+          def optional-line [label: string, value: string]: nothing -> string {
+            match $value {
+              '' => null
+              $set => $"- ($label): ($set)"
+            }
+          }
 
-          if [ "$UPDATE_RESULT" = "failure" ]; then
-            echo ":warning: Some updates failed. Check individual job logs for details." >> $GITHUB_STEP_SUMMARY
-          else
-            echo ":white_check_mark: All update jobs completed." >> $GITHUB_STEP_SUMMARY
-          fi
+          let outcome = match $env.UPDATE_RESULT {
+            'failure' => ':warning: Some updates failed. Check individual job logs for details.'
+            _ => ':white_check_mark: All update jobs completed.'
+          }
+
+          [
+            $"## ($env.SUMMARY_TITLE)"
+            ''
+            '### Configuration'
+            (optional-line 'Inputs' $env.INPUTS)
+            (optional-line 'Excluded' $env.EXCLUDE_INPUTS)
+            (optional-line 'Skip delay' $env.SKIP_DELAY_INPUTS)
+            $"- Minimum release age: ($env.MINIMUM_RELEASE_AGE_DAYS) days"
+            $"- Auto-merge: ($env.AUTO_MERGE)"
+            ''
+            $outcome
+            ''
+          ]
+          | compact
+          | str join "\n"
+          | save --append $env.GITHUB_STEP_SUMMARY

--- a/.github/workflows/_update-flake-reusable.yaml
+++ b/.github/workflows/_update-flake-reusable.yaml
@@ -138,7 +138,7 @@ jobs:
         # checking the repository out.
         run: |
           # Configuration that was left at its default is not worth a summary line.
-          def optional-line [label: string, value: string]: nothing -> string {
+          def optional-line [label: string, value: string] {
             match $value {
               '' => null
               $set => $"- ($label): ($set)"

--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -70,6 +70,8 @@ jobs:
                 print $"PR #($pr.number) rebased"
               }
               _ => {
+                # The conflict details are on stderr, which `complete` captured.
+                print $rebase.stderr
                 print $"::warning::Rebase failed for PR #($pr.number), aborting"
                 git rebase --abort
               }

--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -32,58 +32,66 @@ jobs:
           token: ${{ steps.bot.outputs.token }}
           fetch-depth: 0
 
+      - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+        with:
+          version: '0.114.1'
+
       - name: Rebase open flake update PRs
+        shell: nu {0}
         env:
           GH_TOKEN: ${{ steps.bot.outputs.token }}
         run: |
-          set -euo pipefail
+          const BRANCH_PREFIX = 'update-flake-'
 
-          echo "=== Finding open flake update PRs ==="
+          def commits-behind-main [branch: string]: nothing -> int {
+            git rev-list --count $"origin/($branch)..origin/main" | str trim | into int
+          }
 
-          # Get all open PRs with update-flake- branches
-          prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("update-flake-")) | "\(.number) \(.headRefName)"')
+          def rebase-pr [pr: record] {
+            print $"=== PR #($pr.number) \(($pr.headRefName)) ==="
+            git fetch origin $pr.headRefName
 
-          if [ -z "$prs" ]; then
-            echo "No open flake update PRs found"
-            exit 0
-          fi
+            let behind = (commits-behind-main $pr.headRefName)
+            if $behind == 0 {
+              print 'Already up to date, skipping'
+              return
+            }
 
-          echo "Found PRs to rebase:"
-          echo "$prs"
+            print $"($behind) commit\(s) behind main, rebasing"
+            git checkout -B $pr.headRefName $"origin/($pr.headRefName)"
 
-          # Process each PR
-          echo "$prs" | while read -r pr_number branch_name; do
-            echo ""
-            echo "=== Processing PR #$pr_number (branch: $branch_name) ==="
+            # A conflicting rebase must not fail the run: the remaining branches can
+            # still be rebased, and this one is left for a human to resolve.
+            let rebase = (git rebase origin/main | complete)
+            print $rebase.stdout
+            match $rebase.exit_code {
+              0 => {
+                git push --force origin $pr.headRefName
+                print $"PR #($pr.number) rebased"
+              }
+              _ => {
+                print $"::warning::Rebase failed for PR #($pr.number), aborting"
+                git rebase --abort
+              }
+            }
 
-            # Fetch the branch
-            git fetch origin "$branch_name"
-
-            # Check if branch is behind main
-            behind_count=$(git rev-list --count "origin/$branch_name..origin/main")
-
-            if [ "$behind_count" -eq 0 ]; then
-              echo "Branch is up to date, skipping"
-              continue
-            fi
-
-            echo "Branch is $behind_count commits behind main, rebasing..."
-
-            # Checkout and rebase
-            git checkout -B "$branch_name" "origin/$branch_name"
-
-            if git rebase origin/main; then
-              echo "Rebase successful, force pushing..."
-              git push --force origin "$branch_name"
-              echo "✅ PR #$pr_number rebased successfully"
-            else
-              echo "⚠️ Rebase failed for PR #$pr_number, aborting"
-              git rebase --abort
-            fi
-
-            # Return to main
             git checkout main
-          done
+          }
 
-          echo ""
-          echo "=== Rebase complete ==="
+          let prs = (
+            gh pr list --state open --json number,headRefName
+            | from json
+            | where { |pr| $pr.headRefName | str starts-with $BRANCH_PREFIX }
+          )
+
+          if ($prs | is-empty) {
+            print 'No open flake update PRs found'
+            exit 0
+          }
+
+          print $"Found ($prs | length) flake update PR\(s):"
+          print ($prs | select number headRefName)
+
+          for pr in $prs { rebase-pr $pr }
+
+          print '=== Rebase complete ==='

--- a/.github/workflows/update-node-packages.yaml
+++ b/.github/workflows/update-node-packages.yaml
@@ -36,19 +36,21 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+        with:
+          version: '0.114.1'
+
       - name: Update npm packages
         id: update
+        shell: nu {0}
         run: |
           bash nix/packages/node/update.sh
 
-          # Check if there are any changes
-          if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No updates available"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Updates available"
-          fi
+          # `git diff --quiet` exits 1 when something changed, which Nushell
+          # surfaces as a command failure, so the exit code has to be inspected.
+          let updated = (git diff --quiet | complete | get exit_code) != 0
+          print (if $updated { 'Updates available' } else { 'No updates available' })
+          $"has_changes=($updated)\n" | save --append $env.GITHUB_OUTPUT
 
       - name: Build and test
         if: steps.update.outputs.has_changes == 'true'
@@ -60,22 +62,12 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update.outputs.has_changes == 'true'
+        shell: nu {0}
         env:
           GH_TOKEN: ${{ steps.bot.outputs.token }}
         run: |
-          BRANCH_NAME="chore/update-node-packages-$(date +%Y%m%d)"
-
-          # Create branch and commit
-          git checkout -b "$BRANCH_NAME"
-          git add -A
-          git commit -m "chore(nix): update npm packages for Neovim"
-          git push -u origin "$BRANCH_NAME"
-
-          # Create PR
-          gh pr create \
-            --title "chore(nix): update npm packages for Neovim" \
-            --body "$(cat <<'EOF'
-          ## Summary
+          const TITLE = 'chore(nix): update npm packages for Neovim'
+          const BODY = "## Summary
           - Updates npm packages managed via buildNpmPackage
 
           ## Packages
@@ -84,10 +76,13 @@ jobs:
           - unocss-language-server
 
           ---
-          _This PR was automatically created by the update-node-packages workflow._
-          EOF
-          )" \
-            --label "dependencies,automated"
+          _This PR was automatically created by the update-node-packages workflow._"
 
-          # Enable auto-merge
-          gh pr merge "$BRANCH_NAME" --auto --squash
+          let branch = $"chore/update-node-packages-((date now) | format date '%Y%m%d')"
+
+          git checkout -b $branch
+          git add --all
+          git commit -m $TITLE
+          git push -u origin $branch
+          gh pr create --title $TITLE --body $BODY --base main --head $branch --label dependencies --label automated
+          gh pr merge $branch --auto --squash

--- a/.github/workflows/update-overlays.yaml
+++ b/.github/workflows/update-overlays.yaml
@@ -31,49 +31,62 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
+      - uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
+        with:
+          version: '0.114.1'
+
       - name: Run nix-update on overlay packages
         id: update
+        shell: nu {0}
         run: |
-          set -eo pipefail
+          const OVERLAY_DIR = 'nix/overlays'
+          # Packages that follow the latest GitHub release tag.
+          const TAGGED_PACKAGES = [git-now roots gh-triage]
+          # Packages that follow their default branch HEAD instead of a release.
+          const BRANCH_PACKAGES = [gh-user-stars]
 
-          # Tagged-release packages: follow the latest GitHub release tag.
-          # Unstable-commit packages: follow the default branch HEAD.
-          tagged=(git-now roots gh-triage)
-          branch=(gh-user-stars)
+          # `git diff --quiet` exits 1 when the path differs, which Nushell surfaces as
+          # a command failure, so the exit code has to be inspected instead of raised.
+          def has-changes [path: string, --cached]: nothing -> bool {
+            let scope = if $cached { ['--cached'] } else { [] }
+            (git diff ...$scope --quiet -- $path | complete | get exit_code) != 0
+          }
 
-          updated=()
+          # nix-update fails for packages whose upstream has nothing newer, which is a
+          # normal outcome rather than a reason to stop the run.
+          def update-package [package: string, extra_args: list<string>]: nothing -> bool {
+            print $"::group::nix-update ($package)"
+            try { nix run nixpkgs#nix-update -- --flake ...$extra_args $package } catch {
+              print $"::warning::nix-update failed for ($package)"
+            }
+            print '::endgroup::'
 
-          for pkg in "${tagged[@]}"; do
-            echo "::group::nix-update $pkg"
-            nix run nixpkgs#nix-update -- --flake "$pkg" || true
-            echo "::endgroup::"
-            if ! git diff --quiet -- nix/overlays; then
-              updated+=("$pkg")
-            fi
-            git add nix/overlays
-          done
+            let updated = (has-changes $OVERLAY_DIR)
+            # Stage as we go so the next package is compared against a clean tree.
+            git add $OVERLAY_DIR
+            $updated
+          }
 
-          for pkg in "${branch[@]}"; do
-            echo "::group::nix-update $pkg (branch)"
-            nix run nixpkgs#nix-update -- --flake --version=branch "$pkg" || true
-            echo "::endgroup::"
-            if ! git diff --quiet -- nix/overlays; then
-              updated+=("$pkg")
-            fi
-            git add nix/overlays
-          done
+          let targets = [
+            ...($TAGGED_PACKAGES | each { |package| { name: $package, args: [] } })
+            ...($BRANCH_PACKAGES | each { |package| { name: $package, args: ['--version=branch'] } })
+          ]
 
-          if git diff --cached --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "No overlay updates available"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            {
-              echo "updated_list<<EOF"
-              printf '%s\n' "${updated[@]}"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          fi
+          let updated = (
+            $targets
+            | each { |target| { name: $target.name, updated: (update-package $target.name $target.args) } }
+            | where updated
+            | get name
+          )
+
+          if not (has-changes $OVERLAY_DIR --cached) {
+            print 'No overlay updates available'
+            "has_changes=false\n" | save --append $env.GITHUB_OUTPUT
+            exit 0
+          }
+
+          print $"Updated: ($updated | str join ', ')"
+          $"has_changes=true\nupdated_packages=($updated | to json --raw)\n" | save --append $env.GITHUB_OUTPUT
 
       - name: Build and test
         if: steps.update.outputs.has_changes == 'true'
@@ -86,38 +99,36 @@ jobs:
       - name: Create Pull Request
         id: pr
         if: steps.update.outputs.has_changes == 'true'
+        shell: nu {0}
         env:
           GH_TOKEN: ${{ steps.bot.outputs.token }}
-          UPDATED_LIST: ${{ steps.update.outputs.updated_list }}
+          UPDATED_PACKAGES: ${{ steps.update.outputs.updated_packages }}
         run: |
-          set -eo pipefail
-          BRANCH_NAME="chore/update-overlays-$(date +%Y%m%d-%H%M%S)"
+          const TITLE = 'chore(nix): update custom overlay packages'
 
-          git checkout -b "$BRANCH_NAME"
-          git commit -m "chore(nix): update custom overlay packages"
-          git push -u origin "$BRANCH_NAME"
+          let body = [
+            '## Summary'
+            ''
+            'Updates custom overlay packages via `nix-update`.'
+            ''
+            '### Updated'
+            ...($env.UPDATED_PACKAGES | from json | each { |package| $"- ($package)" })
+            ''
+            '---'
+            '_This PR was automatically created by the update-overlays workflow._'
+          ] | str join "\n"
 
-          updated_md=$(echo "$UPDATED_LIST" | sed '/^$/d; s/^/- /')
+          # A timestamp keeps consecutive runs on separate branches, since each run is
+          # a standalone pull request rather than an update of the previous one.
+          let branch = $"chore/update-overlays-((date now) | format date '%Y%m%d-%H%M%S')"
 
-          body=$(cat <<EOF
-          ## Summary
+          git checkout -b $branch
+          git commit -m $TITLE
+          git push -u origin $branch
+          gh pr create --title $TITLE --body $body --base main --head $branch --label dependencies --label automated
 
-          Updates custom overlay packages via \`nix-update\`.
-
-          ### Updated
-          ${updated_md}
-
-          ---
-          _This PR was automatically created by the update-overlays workflow._
-          EOF
-          )
-
-          pr_url=$(gh pr create \
-            --title "chore(nix): update custom overlay packages" \
-            --body "$body" \
-            --label "dependencies,automated")
-
-          echo "pr_number=${pr_url##*/}" >> "$GITHUB_OUTPUT"
+          let number = (gh pr list --head $branch --json number | from json | get 0.number)
+          $"pr_number=($number)\n" | save --append $env.GITHUB_OUTPUT
 
       - name: Enable auto-merge
         if: steps.update.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

The workflow steps that had grown past "a couple of commands" are now Nushell instead of bash. Structured data is the reason: these scripts spend most of their time reading `nix flake metadata` / `gh api` JSON, comparing timestamps, and assembling matrices and PR bodies — all of which bash can only do through string surgery.

Rewritten:

| Step | Was |
| --- | --- |
| `discover-flake-inputs` | hand-concatenated matrix JSON, two lookup helpers over word-split arrays |
| `update-flake-input` (update) | `date -d` / `date -j` fallbacks, bash associative arrays for version diffs |
| `update-flake-input` (PR) | second copy of the associative-array parsing |
| `auto-rebase` | `gh pr list` text piped through `while read` |
| `update-overlays` | duplicated update loop per package group, heredoc multi-line step output |
| `update-node-packages` | heredoc nested inside a command substitution |
| flake update summary | 15 `echo … >> $GITHUB_STEP_SUMMARY` lines |

Left in bash on purpose: `setup-nix`, `setup-git-bot`, `auto-merge-pr`, the tirith gate and the `nix build` steps — they are a few commands each and gain nothing.

Scripts stay inline with `shell: nu {0}`, so the summary job still needs no checkout. Nushell is pinned to 0.114.1 via `hustcer/setup-nu`.

## Behaviour changes

- Package versions travel between the two `update-flake-input` steps as JSON records instead of `pkg=ver, pkg=ver` strings.
- `update-overlays` output `updated_list` (newline-delimited heredoc) is now `updated_packages` (JSON array).
- The GitHub `until` cutoff is explicitly converted to UTC. `format date` previously emitted local time under a `Z` suffix, which was only correct because runners are UTC.
- PR labels are passed as repeated `--label` flags rather than one comma-joined value.

Everything else is intended to behave exactly as before.

## Testing

- Every inline block extracted from the YAML and parse-checked with `nu --ide-check` (9/9 clean).
- `discover-flake-inputs` run end-to-end against this repo's real `flake.lock`: 19 inputs, exclusions and `skip_delay` honoured, matrix JSON single-line.
- Summary step run with representative inputs; empty configuration lines are omitted as before.
- `update-flake-input` helpers unit-tested against the live GitHub API: `aged-commit` returns found / none / unavailable correctly, the UTC cutoff really does exclude commits newer than the window, and `commit-date` returns null for an unknown revision.
- PR title and body rendered for both the tracked-package and plain-input cases.
- `auto-rebase` PR listing verified against the 5 open flake update PRs.
- One genuine bug caught and fixed this way: `complete` cannot be applied to an already-captured external command result.
- `actionlint` clean, `nix run .#fmt` reports no changes.

Not exercised end-to-end: the steps that mutate the repository (`nix flake update`, `nix-update`, branch push, PR creation) — those only run in the scheduled bot workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor CI workflows to Nushell for safer JSON/date handling and clearer logs across flake updates, overlays, node packages, auto-rebase, and the run summary. Behavior stays the same, with simpler PRs, better rebase visibility, and no extra checkouts.

- **Refactors**
  - Moved long bash steps to Nushell across discovery/update, overlays, node packages, auto-rebase, and summary; scripts run inline via shell: `nu {0}` and `hustcer/setup-nu` is pinned to `0.114.1`.
  - Discovery builds the matrix from records, respects exclude/skip lists, emits compact JSON, and logs excluded/missing inputs.
  - Update step uses datetimes/durations for release-age checks, preselects aged commits via the GitHub API (UTC cutoff), falls back to latest when unavailable, passes package versions as JSON, and renders PR titles/bodies directly.
  - Auto-rebase iterates `gh` JSON, rebases only branches behind `main`, prints both stdout and stderr on conflicts, and continues with the next branch.
  - Overlays/node updates unify loops and change detection via `git diff` exit codes, emit `updated_packages` as JSON, simplify PR bodies, and render the run summary in Nushell without a checkout.

- **Bug Fixes**
  - Use explicit UTC for GitHub commit queries, skip downgrades when a target predates the current revision, handle `git diff --quiet` exit codes in Nushell, pass PR labels as repeated `--label` flags, and make the summary helper return null for omitted lines.

<sup>Written for commit 3237d6d42564a65807c26a1398aa2d95ceaafed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated automated flake, overlay, and package update workflows from Bash to Nushell.
  * Improved workflow handling for change detection, release-age validation, package reporting, and update results.
  * Updated pull request automation to generate clearer summaries, package-version tables, labels, and merge actions.
  * Enhanced automatic rebasing to continue processing remaining updates when conflicts occur.
* **Chores**
  * Standardized Nushell setup across workflow automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->