### PR TITLE
fix(cmux): install agent hooks during nix switch

### DIFF
--- a/nix/modules/home/programs/cmux/default.nix
+++ b/nix/modules/home/programs/cmux/default.nix
@@ -1,7 +1,7 @@
 # docs
 # https://cmux.com/docs/configuration
 
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   jsonFormat = pkgs.formats.json { };
 
@@ -118,6 +118,12 @@ in
     source = jsonFormat.generate "cmux.json" cmuxSettings;
     force = true;
   };
+
+  home.activation.installCmuxHooks = lib.mkIf pkgs.stdenv.isDarwin (
+    lib.hm.dag.entryAfter [ "writeBoundary" "writeCodexConfig" ] ''
+      cmux hooks setup -y
+    ''
+  );
 
   home = {
     packages = [ browserOpen ] ++ (if pkgs.stdenv.isDarwin then [ openShim ] else [ ]);

--- a/nix/modules/home/programs/default.nix
+++ b/nix/modules/home/programs/default.nix
@@ -100,7 +100,7 @@
 
     # cmux terminal configuration
     (import ./cmux {
-      inherit pkgs;
+      inherit pkgs lib;
     })
 
     # Bat configuration


### PR DESCRIPTION
Run cmux hooks setup -y from the macOS Home Manager activation after Codex configuration is written. This installs supported cmux agent integrations during nix switch instead of requiring a manual setup step. Build and test verification were not run by request; the commit hook also could not complete its automatic switch because sudo required an interactive password.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically installs `cmux` agent hooks during macOS Home Manager activation after Codex config is written, so `nix switch` completes setup without a manual step. Also fixes Linux evaluation by passing Home Manager `lib` into the `cmux` module.

- **Bug Fixes**
  - Add `home.activation.installCmuxHooks` to run `cmux hooks setup -y` after `"writeBoundary"` and `"writeCodexConfig"` using `lib.hm.dag.entryAfter`.
  - Gate to macOS via `pkgs.stdenv.isDarwin`.
  - Pass `lib` to the `cmux` module import to avoid Linux evaluation errors.

<sup>Written for commit 4beaaec6f177c9f105b3eb70192e7c6938d02336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/5078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On Darwin systems, cmux hooks are now automatically configured during Home Manager activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->