### PR TITLE
refactor(skills): merge tgrab into web-fetch

### DIFF
--- a/agents/skills/web-fetch/SKILL.md
+++ b/agents/skills/web-fetch/SKILL.md
@@ -6,6 +6,11 @@ description: Fetches and extracts web content with the repository's preferred CL
 # Web Fetch
 
 - For static URLs, discovery, and text extraction, use `./ax <url>`. Read `./ax --help` for current syntax.
-- If `ax` fails, use the host's web fetch/search tool or `curl` for simple HTTP retrieval.
+- For X/Twitter, Bluesky, and YouTube posts or transcripts, use `./tgrab <url>`.
+- Use `./tgrab --lang ja <youtube-url>` when a Japanese YouTube transcript is preferred.
+- If `ax` or `tgrab` fails, use the host's web fetch/search tool or `curl` for simple HTTP retrieval.
 - Use Browser/`agent-browser` for JavaScript, navigation, interaction, login, testing, or screenshots; use Chrome MCP for an existing signed-in session.
-- Use `/tgrab` for X/Twitter, Bluesky, and YouTube posts or transcripts.
+
+Always run `./ax` and `./tgrab` via a subagent to keep the main conversation context clean.
+
+Supported `tgrab` URL patterns include YouTube (`youtube.com/watch`, `youtu.be`, and embeds), X/Twitter status URLs, and Bluesky post URLs.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -36,9 +36,9 @@ Use the `missing-tools` skill when a command is unavailable, a shell reports `co
 
 ## Social Media Posts & YouTube Transcripts
 
-For X/Twitter, Bluesky, and YouTube, use the `tgrab` skill. It provides the packaged `tgrab` executable for fetching supported URLs.
+For X/Twitter, Bluesky, and YouTube, use the `web-fetch` skill. It provides the packaged `tgrab` executable for fetching supported URLs.
 
-Always fetch via a subagent to keep the main conversation clean. See the `tgrab` skill for supported URL patterns and options.
+Always fetch via a subagent to keep the main conversation clean. See the `web-fetch` skill for supported URL patterns and options.
 
 ## Tips
 

--- a/flake.lock
+++ b/flake.lock
@@ -403,7 +403,7 @@
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
-          "tgrab-skill",
+          "tgrab",
           "nixpkgs"
         ]
       },
@@ -446,7 +446,7 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
-          "tgrab-skill",
+          "tgrab",
           "git-hooks",
           "nixpkgs"
         ]
@@ -740,14 +740,14 @@
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2",
-        "tgrab-skill": "tgrab-skill",
+        "tgrab": "tgrab",
         "treefmt-nix": "treefmt-nix_4"
       }
     },
     "rust-overlay": {
       "inputs": {
         "nixpkgs": [
-          "tgrab-skill",
+          "tgrab",
           "nixpkgs"
         ]
       },
@@ -780,7 +780,7 @@
         "type": "github"
       }
     },
-    "tgrab-skill": {
+    "tgrab": {
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts_4",
@@ -849,7 +849,7 @@
     "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
-          "tgrab-skill",
+          "tgrab",
           "nixpkgs"
         ]
       },

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
       flake = false;
     };
 
-    tgrab-skill = {
+    tgrab = {
       url = "github:ryoppippi/tgrab/bf5e8d3b3dc71cea03852af2bfcfc5d529ae91b5";
     };
 
@@ -133,7 +133,7 @@
       agent-skills,
       ast-grep-skill,
       agent-browser-skill,
-      tgrab-skill,
+      tgrab,
       cmux-skill,
       gh-stack-skill,
       ...
@@ -204,7 +204,7 @@
                       fish-na
                       ast-grep-skill
                       agent-browser-skill
-                      tgrab-skill
+                      tgrab
                       cmux-skill
                       gh-stack-skill
                       ;
@@ -592,7 +592,7 @@
                           fish-na
                           ast-grep-skill
                           agent-browser-skill
-                          tgrab-skill
+                          tgrab
                           cmux-skill
                           gh-stack-skill
                           ;

--- a/nix/modules/home/agent-skills.nix
+++ b/nix/modules/home/agent-skills.nix
@@ -9,7 +9,7 @@
   lib,
   ast-grep-skill,
   agent-browser-skill,
-  tgrab-skill,
+  tgrab,
   cmux-skill,
   gh-stack-skill,
   local-skills,
@@ -38,11 +38,6 @@ in
       # External: agent-browser skill
       agent-browser = {
         path = agent-browser-skill;
-        subdir = "skills";
-      };
-      # External: tgrab skill
-      tgrab = {
-        path = tgrab-skill.outPath;
         subdir = "skills";
       };
       cmux = {
@@ -91,23 +86,13 @@ in
           '';
       };
 
-    skills.explicit.tgrab = {
-      from = "tgrab";
-      path = "tgrab";
-      packages = [ tgrab-skill.packages.${pkgs.stdenv.hostPlatform.system}.default ];
-      rewriteCommands = false;
-      transform =
-        { original, dependencies }:
-        ''
-          ${builtins.replaceStrings [ "nix run github:ryoppippi/tgrab --" ] [ "./tgrab" ] original}
-          ${dependencies}
-        '';
-    };
-
     skills.explicit.web-fetch = {
       from = "local";
       path = "web-fetch";
-      packages = [ pkgs.llm-agents.ax ];
+      packages = [
+        pkgs.llm-agents.ax
+        tgrab.packages.${pkgs.stdenv.hostPlatform.system}.default
+      ];
       rewriteCommands = false;
     };
 

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -9,7 +9,7 @@
   fish-na ? null,
   ast-grep-skill ? null,
   agent-browser-skill ? null,
-  tgrab-skill ? null,
+  tgrab ? null,
   cmux-skill ? null,
   gh-stack-skill ? null,
   local-skills ? null,
@@ -36,7 +36,7 @@ in
         lib
         ast-grep-skill
         agent-browser-skill
-        tgrab-skill
+        tgrab
         cmux-skill
         gh-stack-skill
         local-skills


### PR DESCRIPTION
Consolidate social-media and YouTube fetching into the existing web-fetch skill. The web-fetch package now includes both `ax` and `tgrab`, removes the redundant standalone tgrab skill source, and updates the shared agent instructions accordingly.

Verified with `gh-nix nix run .#build`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged `tgrab` into the `web-fetch` skill so social media posts and YouTube transcripts are fetched through one tool. `web-fetch` now includes both `ax` and `tgrab`; the standalone `tgrab` skill is removed.

- **Refactors**
  - Bundle `tgrab` with `web-fetch`; add `./tgrab` usage, `--lang ja` option, and supported URL patterns in `SKILL.md`.
  - Update `codex/AGENTS.md` to route X/Twitter, Bluesky, and YouTube through `web-fetch`.
  - Remove explicit `tgrab` skill wiring; `web-fetch` now packages `ax` and `tgrab` in `agent-skills.nix`.

- **Dependencies**
  - Replace the `tgrab-skill` flake input with `tgrab` and update references across `flake.nix`, `flake.lock`, and home modules.

<sup>Written for commit 8cf553b95a6f8539912fc200b60273efe58171ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded web-fetch guidance for X/Twitter, Bluesky, and YouTube content, including Japanese transcripts and supported URL patterns.
  - Improved retrieval instructions and fallback guidance for supported social media and video content.

- **Improvements**
  - Consolidated content retrieval tools under the web-fetch experience.
  - Simplified setup and configuration for the updated retrieval workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->