### PR TITLE
feat(skills): attach UI media when creating pull requests

### DIFF
--- a/agents/skills/create-pr/SKILL.md
+++ b/agents/skills/create-pr/SKILL.md
@@ -34,7 +34,15 @@ A PR is a reviewable responsibility unit; one PR may contain multiple atomic com
    - For a larger change, include Summary, What Changed, Why, and Testing only when tests were actually run. Add Related Issues only when relevant.
    - Use `--body-file -` for multi-line bodies. Do not embed `\n` escape sequences in `--body`.
 
-6. Publish using the path that matches the PR structure:
+6. When the change is visual (UI, layout, rendering, or a bug that is clearer on screen), attach local screenshots or short videos to the PR with `gh pr create --attach` (`gh` ≥ 2.99.0). Prefer real artifacts already produced while implementing or testing — do not invent media, and skip attach when there is nothing useful to show. If `gh pr create --help` does not list `--attach`, skip media upload and open the PR with text only (nixpkgs will pick up a new enough `gh` in time).
+
+   - Put Markdown image/video references in the body using local paths (e.g. `![Login after fix](./after.png)`). `gh` rewrites those paths to uploaded URLs in place and keeps the alt text.
+   - Pass each file with `--attach` (repeatable). Optional alt text after `#` when the body does not already reference the path: `--attach './after.png#Login after fix'`.
+   - Supported types include PNG, JPEG, GIF, WebP, SVG, MP4, MOV, and WebM. Size limits match the web upload flow.
+   - If media appears only after the PR exists (e.g. a walkthrough recorded while verifying), attach it with `gh pr edit --attach` or `gh pr comment --attach` instead of recreating the PR.
+   - See `gh pr create --help` for flag syntax. Overview: https://gh.io/gh-attach
+
+7. Publish using the path that matches the PR structure:
 
    - Use `gh-stack` only when requested or when the branch is already stacked; verify parent-child ancestry before linking.
    - For an ordinary PR, push the branch and create the PR with:
@@ -44,6 +52,8 @@ A PR is a reviewable responsibility unit; one PR may contain multiple atomic com
      gh pr create --title "feat(scope): summary" --body-file -
      ```
 
-7. Report the PR URL. If publishing fails, inspect the error and verify the branch, remote, authentication, or duplicate PR state before retrying.
+     When step 6 produced media, add one `--attach <path>` (or `--attach 'path#alt'`) per file on that `gh pr create` invocation.
+
+8. Report the PR URL. If publishing fails, inspect the error and verify the branch, remote, authentication, `gh` version, or duplicate PR state before retrying.
 
 All commit messages, PR titles, and PR bodies must be in English. Confirm the target branch before creating the PR, and do not call it ready until the relevant checks and review feedback have been inspected.

--- a/agents/skills/create-pr/SKILL.md
+++ b/agents/skills/create-pr/SKILL.md
@@ -34,13 +34,7 @@ A PR is a reviewable responsibility unit; one PR may contain multiple atomic com
    - For a larger change, include Summary, What Changed, Why, and Testing only when tests were actually run. Add Related Issues only when relevant.
    - Use `--body-file -` for multi-line bodies. Do not embed `\n` escape sequences in `--body`.
 
-6. When the change is visual (UI, layout, rendering, or a bug that is clearer on screen), attach local screenshots or short videos to the PR with `gh pr create --attach` (`gh` ≥ 2.99.0). Prefer real artifacts already produced while implementing or testing — do not invent media, and skip attach when there is nothing useful to show. If `gh pr create --help` does not list `--attach`, skip media upload and open the PR with text only (nixpkgs will pick up a new enough `gh` in time).
-
-   - Put Markdown image/video references in the body using local paths (e.g. `![Login after fix](./after.png)`). `gh` rewrites those paths to uploaded URLs in place and keeps the alt text.
-   - Pass each file with `--attach` (repeatable). Optional alt text after `#` when the body does not already reference the path: `--attach './after.png#Login after fix'`.
-   - Supported types include PNG, JPEG, GIF, WebP, SVG, MP4, MOV, and WebM. Size limits match the web upload flow.
-   - If media appears only after the PR exists (e.g. a walkthrough recorded while verifying), attach it with `gh pr edit --attach` or `gh pr comment --attach` instead of recreating the PR.
-   - See `gh pr create --help` for flag syntax. Overview: https://gh.io/gh-attach
+6. When the change is visual (UI, layout, rendering, or a bug clearer on screen), attach real local screenshots or short videos with `gh pr create --attach`. Do not invent media; skip when there is nothing useful to show, or when `gh pr create --help` does not list `--attach`. Prefer Markdown references to local paths in the body so alt text survives upload. If media appears only after the PR exists, attach with `gh pr edit` / `gh pr comment` instead of recreating the PR. See `gh pr create --help` and https://gh.io/gh-attach.
 
 7. Publish using the path that matches the PR structure:
 
@@ -52,8 +46,8 @@ A PR is a reviewable responsibility unit; one PR may contain multiple atomic com
      gh pr create --title "feat(scope): summary" --body-file -
      ```
 
-     When step 6 produced media, add one `--attach <path>` (or `--attach 'path#alt'`) per file on that `gh pr create` invocation.
+     Add `--attach` on that invocation when step 6 applies.
 
-8. Report the PR URL. If publishing fails, inspect the error and verify the branch, remote, authentication, `gh` version, or duplicate PR state before retrying.
+8. Report the PR URL. If publishing fails, inspect the error and verify the branch, remote, authentication, or duplicate PR state before retrying.
 
 All commit messages, PR titles, and PR bodies must be in English. Confirm the target branch before creating the PR, and do not call it ready until the relevant checks and review feedback have been inspected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Update the `create-pr` skill so visual/UI changes attach real screenshots or videos via `gh pr create --attach`.

## What changed

- When the change is visual, attach real local media (skip if nothing useful, or if `--attach` is missing from help).
- Prefer Markdown local-path references in the body; defer to `gh pr create --help` / https://gh.io/gh-attach for formats and flag syntax.
- No flake/`gh` package bump — wait for nixos-unstable.

## Refs

- https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06157-486c-7d24-8a1b-cc15bb2772d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06157-486c-7d24-8a1b-cc15bb2772d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `create-pr` skill so visual PRs attach local screenshots and videos with `gh pr create --attach` instead of leaving those artifacts out. The feature requires `gh` 2.99.0 or newer; older versions fall back to a text-only PR.

- Uses local Markdown media paths so uploaded URLs preserve alt text.
- Supports later uploads with `gh pr edit --attach` or `gh pr comment --attach`.
- Skips attachments when no useful media exists.

<sup>Written for commit a5b78617a2a188a153d62d6b8d665c87ecf0c2a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/dotfiles/pull/5343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified visual-media guidance for pull request creation.
  - Removed detailed attachment syntax, supported formats, size limits, and post-creation attachment commands.
  - Updated publishing instructions to use `--attach` when applicable.
  - Removed `gh` version checks from failure troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->